### PR TITLE
ECOMMONS-1681 - hardcodes server url for google's pdf meta tag

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/GoogleMetadata.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/GoogleMetadata.java
@@ -898,7 +898,9 @@ public class GoogleMetadata {
             Bitstream bitstream = findLinkableFulltext(item);
             if (bitstream != null) {
                 StringBuilder path = new StringBuilder();
-                path.append(configurationService.getProperty("dspace.ui.url"));
+                // CUL OVERRIDE - use ecommons URL since dspace.ui.url is set to localhost:4000
+                // path.append(configurationService.getProperty("dspace.ui.url"));
+                path.append("https://ecommons.cornell.edu");
 
                 if (item.getHandle() != null) {
                     path.append("/bitstream/");


### PR DESCRIPTION
A little strange that this is needed since the backend.env file on prod includes:
```
ECOMMONS_DSPACE_SERVER_URL=https://ecommons.cornell.edu/server
ECOMMONS_DSPACE_UI_URL=https://ecommons.cornell.edu
```

